### PR TITLE
Wiki/redsachievementruleupdate

### DIFF
--- a/src/content/pages/darksouls/all-achievements.mdoc
+++ b/src/content/pages/darksouls/all-achievements.mdoc
@@ -2,13 +2,13 @@
 title: All Achievements
 hidden: false
 ---
-[**Dark Souls**](/darksouls)  **All Achievements** is a speedrun category in which the player attempts to gain all possible Achievements (on Steam/Xbox 360) or Trophies (on PlayStation 3) as fast as possible. There are no added restrictions on how the player completes this task, they must simply start a new character and gain the final achievement, *The Dark Soul*, as quickly as they can. [Glitches](/glitches), skips and sequence breaks are all allowed. Using other programs to affect the game or editing the game code is not allowed; apart from a few exceptions allowed by the community.
+[**Dark Souls**](/darksouls)    **All Achievements** is a speedrun category in which the player attempts to gain all possible Achievements (on Steam/Xbox 360) or Trophies (on PlayStation 3) as fast as possible. There are no added restrictions on how the player completes this task, they must simply start a new character and gain the final achievement, *The Dark Soul*, as quickly as they can. [Glitches](/glitches), skips and sequence breaks are all allowed. Using other programs to affect the game or editing the game code is not allowed; apart from a few exceptions allowed by the community.
 
 The leaderboards for this category are available [here](https://www.speedrun.com/darksouls/all_achievements).
 
 The Windows application [Steam Achievement Manager](https://github.com/gibbed/SteamAchievementManager) by gibbed can be used to remove already acquired achievements on your Steam profile. Make sure to follow the instructions on the developers website. Sometimes the Steam Achievement Manager is unable to find your steam games automatically after a steam update. Use the ID 211420 to manually add the PTDE edition and reset your achievements that way.
 
-CapitaineToinon's LiveSplit plugin [ResetAllStats](https://github.com/CapitaineToinon/LiveSplit.ResetAllStats) can also be used. On consoles, it is possible to play on a new user profile to regain achievements/trophies. Runs without achievements/trophies being shown will be denied.
+CapitaineToinon's LiveSplit plugin [ResetAllStats](https://github.com/CapitaineToinon/LiveSplit.ResetAllStats) can also be used.
 
 Submitted runs without visible Achievement popups **will not be accepted**, any solution to reset your achievements is therefore compulsory. This is due to ease of tracking achievements during a run and in verifying a run. On consoles, it is possible to play on a new user profile to regain achievements/trophies.
 
@@ -28,7 +28,6 @@ Submitted runs without visible Achievement popups **will not be accepted**, any 
 
 (The rules listed here are specific to this category. Go to [**this page**](/darksouls#rules) to find the rules that apply to all Dark Souls speedruns.)
 
-- Like all Dark Souls speedruns the run time is recorded using the In-Game Timer. After the run is finished, quit to the Load Game menu to see the In-Game time.
-- You may not use savefiles. Savefile runs are common when practicing categories with weapons that do not have 100% drop rates but these are not counted as 'official' times. Savefiles can also be abused to retry sections to improve the IGT so they are not allowed.
-- Glitches, skips and sequence breaks are all **allowed.**    [Duke Skip](/duke-skip), [Ceaseless Skip](/ceaseless-skip), [Item Dupe](/item-dupe-darksouls), [Moveswap](/moveswap) and Toggle Escape (amongst others) are all fair-game.
-- It is not allowed to force quit the game after getting an achievement but before it autosaves (for example when doing the weapon upgrades).
+- You must collect all 41 achievements/trophies to finish this speedrun. Achievements/Trophies **must** show up on screen when they are attained (see above for methods to reset your achievements/trophies). Runs with no visible achievement/trophy pop-ups will be **denied**.
+- Glitches, skips and sequence breaks are all **allowed.**
+- Time stops when you quit to the main menu or trigger the credits after performing the last action required to achieve *The Dark Soul*.

--- a/src/content/pages/ds1remaster/all-achievements.mdoc
+++ b/src/content/pages/ds1remaster/all-achievements.mdoc
@@ -1,26 +1,35 @@
 ---
-title: "All Achievements"
+title: All Achievements
+hidden: false
 ---
-
-**[Dark Souls Remastered](/ds1remaster) All Achievements** is a speedrun category in which the player attempts to gain all possible Achievements (on Steam/Xbox one/Xbox Series) or Trophies (on PlayStation 4/Playstation 5) as fast as possible. There are no added restrictions on how the player completes this task, they must simply start a new character and gain the final achievement, _The Dark Soul_, as quickly as they can. [Glitches](/glitches), skips and sequence breaks are all allowed. Using other programs to affect the game or editing the game code is not allowed; apart from a few exceptions allowed by the community.
+[**Dark Souls Remastered**](/ds1remaster) **All Achievements** is a speedrun category in which the player attempts to gain all possible Achievements (on Steam/Xbox one/Xbox Series) or Trophies (on PlayStation 4/Playstation 5) as fast as possible. There are no added restrictions on how the player completes this task, they must simply start a new character and gain the final achievement, *The Dark Soul*, as quickly as they can. [Glitches](/glitches), skips and sequence breaks are all allowed. Using other programs to affect the game or editing the game code is not allowed; apart from a few exceptions allowed by the community.
 
 The leaderboards for this category are available [here](https://www.speedrun.com/darksoulsremastered/all_achievements).
 
 The Windows application [Steam Achievement Manager](https://github.com/gibbed/SteamAchievementManager) by gibbed can be used to remove already acquired achievements on your Steam profile. Make sure to follow the instructions on the developers website. Sometimes the Steam Achievement Manager is unable to find your steam games automatically after a steam update. Use the ID 570940 to manually add the remastered and reset your achievements that way.
 
-CapitaineToinon's LiveSplit plugin [ResetAllStats](https://github.com/CapitaineToinon/LiveSplit.ResetAllStats) can also be used. On consoles, it is possible to play on a new user profile to regain achievements/trophies. Runs without achievements/trophies being shown will be denied.
+CapitaineToinon's LiveSplit plugin [ResetAllStats](https://github.com/CapitaineToinon/LiveSplit.ResetAllStats) can also be used.
 
 Submitted runs without visible Achievement popups **will not be accepted**, any solution to reset your achievements is therefore compulsory. This is due to ease of tracking achievements during a run and in verifying a run. On consoles, it is possible to play on a new user profile to regain achievements/trophies.
 
 ## Routes
 
-| Route                                    | Estimated possible time | Current Record | Runner   | VOD                                                                                                                         |
-| ---------------------------------------- | ----------------------- | -------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| [Sorcery](https://pastebin.com/XABkeeb8) | -                       | 1:59:47        | Catalyst | [(https://youtu.be/Ylu3_O3pto4) |
+{% table %}
+- Route
+- Estimated possible time
+- Current Record
+- Runner
+- VOD
+---
+- [Sorcery](https://pastebin.com/XABkeeb8)
+- -
+- 1:59:47
+- Catalyst
+- [(https://youtu.be/Ylu3_O3pto4)
+{% /table %}
 
 ## Rules
 
-- Like all Dark Souls speedruns the run time is recorded using the In-Game Timer. After the run is finished, quit to the Load Game menu to see the In-Game time.
-- You may not use savefiles. Savefile runs are common when practicing categories with weapons that do not have 100% drop rates but these are not counted as 'official' times. Savefiles can also be abused to retry sections to improve the IGT so they are not allowed.
-- [Glitches](/glitches), skips and sequence breaks are all **allowed.** [Duke Skip](/duke-skip), [Ceaseless Skip](/ceaseless-skip), and [Toggle Escape](/darksouls/toggle-escape) (amongst others) are all fair-game.
-- It is not allowed to force quit the game after getting an achievement but before it autosaves (for example when doing the weapon upgrades).
+- You must collect all 41 achievements/trophies to finish this speedrun. Achievements/Trophies **must** show up on screen when they are attained (see above for methods to reset your achievements/trophies). Runs with no visible achievement/trophy pop-ups will be **denied**.
+- [Glitches](/glitches), skips and sequence breaks are all **allowed.**
+- Time stops when you quit to the main menu or trigger the credits after performing the last action required to achieve *The Dark Soul*.


### PR DESCRIPTION
For both DSR and PTDE:
shortened the main text, as both after the mention of Toinons livesplit plugin and the subsequent paragraph, it was mentioned that runs without the achievements shown will be denied and that consoles can create new profiles. Now it is only mentioned once.

Updated the rules to include a timing rule. Deleted rules that repeated game-wide rules (timed with IGT, no use of savefiles, no alt+f4) in line with how rules are written for other categories.