### PR TITLE
Update src/content/pages/darksouls3/frequently-asked-questions

### DIFF
--- a/src/content/pages/darksouls3/frequently-asked-questions.mdoc
+++ b/src/content/pages/darksouls3/frequently-asked-questions.mdoc
@@ -1,76 +1,79 @@
 ---
-title: "Frequently Asked Questions"
+title: Frequently Asked Questions
+hidden: false
 ---
-
 ## Item Dupe & Tumblebuff
 
 - **I can't Item Dupe or Tumblebuff. Why?**
 
-**\*[Item_Dupe](/darksouls3/item-dupe) & [Tumblebuff](/darksouls3/tumblebuff)** do **NOT** work in current patch. There is no different method as of right now. Read the respective wiki page or **[Downpatching](/darksouls3/downpatching)** for further information.\*
+**\***[**Item\_Dupe**](/darksouls3/item-dupe) **&** [**Tumblebuff**](/darksouls3/tumblebuff) do **NOT** work in current patch. There is no different method as of right now. Read the respective wiki page or [**Downpatching**](/darksouls3/downpatching) for further information.*
 
 ## Downpatching
 
 - **Steam console is not working. Why?**
 
-_Launch Steam (**NOT** Offline Mode). Download the latest release of **[Steam Manifest Patcher](https://github.com/fifty-six/zig.SteamManifestPatcher/releases)**. Launch SteamDepotDownpatcher.exe. Try again. If you receive any error, try restarting Steam. Note that you have to launch SteamDepotDownpatcher.exe again whenever you restart Steam if you want to download a depot. Alternatively, use **[DepotDownloader](https://github.com/SteamRE/DepotDownloader)**._
+*Launch Steam (****NOT*** *Offline Mode). Download the latest release of* [***Steam Manifest Patcher***](https://github.com/fifty-six/zig.SteamManifestPatcher/releases)*. Launch SteamDepotDownpatcher.exe. Try again. If you receive any error, try restarting Steam. Note that you have to launch SteamDepotDownpatcher.exe again whenever you restart Steam if you want to download a depot. Alternatively, use* [***DepotDownloader***](https://github.com/SteamRE/DepotDownloader)*.*
 
-- **I am getting an error during the downpatching process using the [Downpatcher](https://wiki.speedsouls.com/Dark_Souls_III_Downpatcher).**
+- **I am getting an error during the downpatching process using the** [**Downpatcher**](https://wiki.speedsouls.com/Dark_Souls_III_Downpatcher)**.**
 
-_Make sure to use **vanilla** game files, without any modification or additional files in your game folder, before attempting to downpatch using this method. **Verify integrity** of your files via Steam or, if you still get an error: **uninstall** Dark Souls III, make sure C:\Program Files (x86)\Steam\steamapps\common\DARK SOULS III is **deleted**, **reinstall** Dark Souls III. Repeat the downpatching process. If you still get an error, consider using a different method like **[Downpatching](https://wiki.speedsouls.com/Downpatching)**._
+*Make sure to use* ***vanilla*** *game files, without any modification or additional files in your game folder, before attempting to downpatch using this method.* ***Verify integrity*** *of your files via Steam or, if you still get an error:* ***uninstall*** *Dark Souls III, make sure C:\Program Files (x86)\Steam\steamapps\common\DARK SOULS III is* ***deleted***\*,* ***reinstall*** *Dark Souls III. Repeat the downpatching process. If you still get an error, consider using a different method like* [***Downpatching***](https://wiki.speedsouls.com/Downpatching)*.*
 
 - **My game won't launch or I get a blackscreen after downpatching.**
 
-_Make sure Steam is not trying to auto-update your game by right-clicking Dark Souls III in your library > Properties > Updates > set "Automatic Updates" to "Only update this game when I launch it" (or change the value for AutoUpdateBehavior to 1 in C:\Program Files (x86)\Steam\steamapps\appmanifest_374320.acf). Try to delete your existing game folder before replacing it with the appropriate version. This is to prevent any errors from additional files (e.g. any modification to the game folder prior to downpatching). Delete your save file again before letting the game create a new file on launch. If you are still experiencing random crashes or your game does not launch, consider re-downloading the appropriate version. If you are using the **[Downpatcher](https://wiki.speedsouls.com/Dark_Souls_III_Downpatcher)**, see answer above._
+*Make sure Steam is not trying to auto-update your game by right-clicking Dark Souls III in your library > Properties > Updates > set "Automatic Updates" to "Only update this game when I launch it" (or change the value for AutoUpdateBehavior to 1 in C:\Program Files (x86)\Steam\steamapps\appmanifest\_374320.acf). Try to delete your existing game folder before replacing it with the appropriate version. This is to prevent any errors from additional files (e.g. any modification to the game folder prior to downpatching). Delete your save file again before letting the game create a new file on launch. If you are still experiencing random crashes or your game does not launch, consider re-downloading the appropriate version. If you are using the* [***Downpatcher***](https://wiki.speedsouls.com/Dark_Souls_III_Downpatcher)*, see answer above.*
 
 - **After downpatching, I am on Version 1.XX Regulation 1.35. Is this right?**
 
-_This is not right. First, try and delete your save file: Open Search Bar and type %appdata% OR press Windows Key + R and type %appdata% > hit enter > go to DarkSoulsIII folder > Open the folder with a bunch of numbers and letters > backup the .sl2 files and remove them from the AppData folder and restart the game. If that does not work, replace your **Data0** files in your \Game directory with the Data0 files from the appropriate downpatch version (refer to our **[Discord server](http://discord.speedsouls.com/)**). These files hold the regulation changes of the game. If that does not work, please consider downpatching again._
+*This is not right. First, try and delete your save file: Open Search Bar and type %appdata% OR press Windows Key + R and type %appdata% > hit enter > go to DarkSoulsIII folder > Open the folder with a bunch of numbers and letters > backup the .sl2 files and remove them from the AppData folder and restart the game. If that does not work, replace your* ***Data0*** *files in your \Game directory with the Data0 files from the appropriate downpatch version (refer to our* [***Discord server***](http://discord.speedsouls.com/)*). These files hold the regulation changes of the game. If that does not work, please consider downpatching again.*
 
 - **My game is crashing repeatedly in the second DLC.**
 
-_See answer above._
+*See answer above.*
 
 - **"The game version and save data version are different."**
 
-_Delete your save file like mentioned above. Deleting your character does **NOT** equal deleting your save file._
+*Delete your save file like mentioned above. Deleting your character does* ***NOT*** *equal deleting your save file.*
 
 ## Save Organizer
 
 - **I'm having trouble locating my save file.**
 
-_AppData is hidden by default. To locate it, press Windows Key + R, type **%appdata%** and hit enter or: open File Explorer > View > Hidden Items and follow C:\Users\\\<your username>\AppData\Roaming\DarkSoulsIII\\\<numbers>._
+*AppData is hidden by default. To locate it, press Windows Key + R, type* ***%appdata%*** *and hit enter or: open File Explorer > View > Hidden Items and follow C:\Users<your username>\AppData\Roaming\DarkSoulsIII<numbers>.*
 
 ## Controls
 
 - **My controller is not working anymore after downpatching. Why?**
 
-_There is no definite solution to this as of right now. Try re-installing USB or controller specific drivers or use a different USB slot. Consider a different tool for controller support._
+*There is no definite solution to this as of right now. Try re-installing USB or controller specific drivers or use a different USB slot. Consider a different tool for controller support.*
 
 - **My character is drifting or stops running when turning left/right via keyboard, preventing me from jumping.**
 
-_Make sure to increase your controller deadzone via **[Durazno](/darksouls3/durazno)** or Steam until the above mentioned issues are solved. Alternatively, unplug your controller whenever you need to use your keyboard._
+*Make sure to increase your controller deadzone Steam until the above mentioned issues are solved. Alternatively, unplug your controller whenever you need to use your keyboard.*
+
+- **I can't get Durazno working to set controller deadzone.**
+
+*Durazno has been unmaintained for years now and probably does not work anymore. Steam input is anyway a much better way to achieve the same.*
 
 ## Invasions
 
 - **I get invaded even though I am offline in Steam. Why?**
 
-_To avoid NPC invasions (not Hodrick), Steam needs to be in Offline Mode as shown below. Appearing as offline in Steam does **NOT** equal Offline Mode._
-_Note that you can not prevent NPC invasions in version 1.04 1.05. There is no currently known way to prevent NPC invasions on console. Alternatively, you can select System > Quit Game before getting invaded, then quitout once you are past the event trigger._
+*To avoid NPC invasions (not Hodrick), Steam needs to be in Offline Mode as shown below. Appearing as offline in Steam does* ***NOT*** *equal Offline Mode.*  *Note that you can not prevent NPC invasions in version 1.04 1.05. There is no currently known way to prevent NPC invasions on console. Alternatively, you can select System > Quit Game before getting invaded, then quitout once you are past the event trigger.*
 
 ## Modification
 
 - **Are the Save Organizer or any of the listed mods safe to use online?**
 
-_Please do not ask if any specific mod is going to get you banned. It is unlikely you are going to get a reliable answer here. The **[Save Organizer](https://wiki.speedsouls.com/SpeedSouls_-_Save_Organizer)** does not modify Dark Souls III in any way. Keep a **backup** of your **files** without any modification to use online. Do not use any of the listed mods unless Steam is in **Offline Mode**._
+*Please do not ask if any specific mod is going to get you banned. It is unlikely you are going to get a reliable answer here. The* [***Save Organizer***](https://wiki.speedsouls.com/SpeedSouls_-_Save_Organizer) *does not modify Dark Souls III in any way. Keep a* ***backup*** *of your* ***files*** *without any modification to use online. Do not use any of the listed mods unless Steam is in* ***Offline Mode***\*.*
 
 ## Doll Skip
 
-- **I fall to my death in Irithyll when using [Doll Skip](https://wiki.speedsouls.com/Doll_Skip) in Any% No TearDrop. Why?**
+- **I fall to my death in Irithyll when using** [**Doll Skip**](https://wiki.speedsouls.com/Doll_Skip) **in Any% No TearDrop. Why?**
 
-_In order to complete the entire skip, you can not quitout at any point after using spook to drop out of bounds, as Irithyll will not be loaded in otherwise._
+*In order to complete the entire skip, you can not quitout at any point after using spook to drop out of bounds, as Irithyll will not be loaded in otherwise.*
 
 ## Misc.
 
 - **I can't do a certain strategy in the speedrun.**
 
-_Refer to **[Dark_Souls_III](/darksouls3)** as well as the respective page for any **[Glitch or Skip](<https://wiki.speedsouls.com/Category:Glitch_(Dark_Souls_III)>)** you might struggle with. If you still have a question, refer to our **[Discord server](http://discord.speedsouls.com/)**._
+*Refer to* [***Dark\_Souls\_III***](/darksouls3) *as well as the respective page for any* [***Glitch or Skip***](https://wiki.speedsouls.com/Category:Glitch_\(Dark_Souls_III\)) *you might struggle with. If you still have a question, refer to our* [***Discord server***](http://discord.speedsouls.com/)*.*


### PR DESCRIPTION
Added a paragraph in "Controls" explaining that Durazno is no longer supported and Steam inputs is a better way to set conroller deadzones