### PR TITLE
Update src/content/pages/darksouls3/doll-skip

### DIFF
--- a/src/content/pages/darksouls3/doll-skip.mdoc
+++ b/src/content/pages/darksouls3/doll-skip.mdoc
@@ -12,7 +12,11 @@ hidden: false
 
 {% youtube src="https://youtu.be/ys2HFZY2BpU" /%}
 
-## Tutorial Videos
+## Tutorial Video
+
+{% youtube src="https://www.youtube.com/watch?v=R1MZCLIHbK4" /%}
+
+## Doll Skip Segments in Route Tutorials
 
 Used in [**Any%**](/darksouls3/any). Tutorial by [**Fudge Cow**](//youtu.be/KM3U8O2PcU0)
 


### PR DESCRIPTION
Added a dedicated tutorial video to the Doll Skip page to go along with the showcase video, and separated the tutorials featured in full route tutorials to be under a new heading called "Doll Skip Segments in Route Tutorials".